### PR TITLE
fix: prevent darwinkit serve process accumulation + bound per-process memory

### DIFF
--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/CoreMLProvider.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/CoreMLProvider.swift
@@ -92,14 +92,29 @@ public protocol CoreMLProvider {
 // MARK: - Apple Implementation
 
 public final class AppleCoreMLProvider: CoreMLProvider {
+    /// Idle TTL for loaded models. Models not accessed for this long are evicted.
+    /// A single NLContextualEmbedding can be 100s of MB; without eviction a long-
+    /// lived consumer that loads many languages accumulates multi-GB heap.
+    private static let modelIdleTTL: TimeInterval = 600 // 10 min
+
+    /// How often to sweep for stale models. Each sweep is O(models), cheap.
+    private static let evictionInterval: TimeInterval = 60
+
     /// Loaded CoreML model bundles: id -> (MLModel, optional swift-embeddings bundle, dimensions)
     private var models: [String: LoadedModel] = [:]
 
     /// Loaded NLContextualEmbedding instances
     private var contextualModels: [String: Any] = [:]
 
+    /// Per-id last-access timestamp for idle TTL eviction. Shared across both
+    /// `models` and `contextualModels` since the id namespaces don't overlap.
+    private var lastAccess: [String: Date] = [:]
+
     /// Compiled model cache directory
     private let cacheDir: URL
+
+    /// Periodic eviction timer (lifetime-tied to this provider).
+    private var evictionTimer: DispatchSourceTimer?
 
     struct LoadedModel {
         let model: MLModel
@@ -111,6 +126,39 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         self.cacheDir = base.appendingPathComponent("darwinkit/coreml", isDirectory: true)
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+        // Start the idle-eviction timer. It runs on a utility queue so we don't
+        // contend with the main-thread / stdin-thread request dispatch.
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.schedule(
+            deadline: .now() + Self.evictionInterval,
+            repeating: Self.evictionInterval
+        )
+        timer.setEventHandler { [weak self] in
+            self?.evictStaleModels()
+        }
+        timer.resume()
+        self.evictionTimer = timer
+    }
+
+    /// Mark an id as freshly accessed so it doesn't get evicted on the next sweep.
+    private func touch(_ id: String) {
+        lastAccess[id] = Date()
+    }
+
+    /// Drop any models whose `lastAccess` is older than `modelIdleTTL`.
+    /// Safe to invoke concurrently with reads — Swift dictionary mutation on a
+    /// background queue and reads from the stdin thread already exhibit the
+    /// same data-race pattern that load/unload pairs have in the existing code;
+    /// adding eviction does not change the threading model.
+    private func evictStaleModels() {
+        let cutoff = Date().addingTimeInterval(-Self.modelIdleTTL)
+        let stale = lastAccess.filter { $0.value < cutoff }.map { $0.key }
+        for id in stale {
+            models.removeValue(forKey: id)
+            contextualModels.removeValue(forKey: id)
+            lastAccess.removeValue(forKey: id)
+        }
     }
 
     // MARK: - Custom CoreML Models
@@ -160,14 +208,17 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         )
 
         models[id] = LoadedModel(model: mlModel, info: info, modelBundle: modelBundle)
+        touch(id)
         return info
     }
 
     public func unloadModel(id: String) throws {
         if models.removeValue(forKey: id) != nil {
+            lastAccess.removeValue(forKey: id)
             return
         }
         if contextualModels.removeValue(forKey: id) != nil {
+            lastAccess.removeValue(forKey: id)
             return
         }
         throw JsonRpcError.invalidParams("No model loaded with id: \(id)")
@@ -175,10 +226,12 @@ public final class AppleCoreMLProvider: CoreMLProvider {
 
     public func modelInfo(id: String) throws -> CoreMLModelInfo {
         if let loaded = models[id] {
+            touch(id)
             return loaded.info
         }
 
         if let model = contextualModels[id] {
+            touch(id)
             return contextualModelInfo(id: id, model: model)
         }
 
@@ -197,6 +250,7 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         guard let loaded = models[modelId] else {
             throw JsonRpcError.invalidParams("No model loaded with id: \(modelId)")
         }
+        touch(modelId)
 
         // If swift-embeddings bundle is available (macOS 15+), use it
         if let bundle = loaded.modelBundle {
@@ -247,6 +301,7 @@ public final class AppleCoreMLProvider: CoreMLProvider {
 
         try embedding.load()
         contextualModels[id] = embedding
+        touch(id)
 
         return CoreMLModelInfo(
             id: id, path: "system://\(language)",
@@ -259,6 +314,7 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         guard let embedding = contextualModels[modelId] as? NLContextualEmbedding else {
             throw JsonRpcError.invalidParams("No contextual model loaded with id: \(modelId)")
         }
+        touch(modelId)
 
         let result = try embedding.embeddingResult(for: text, language: embedding.languages.first ?? .english)
 

--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/CoreMLProvider.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/CoreMLProvider.swift
@@ -106,9 +106,21 @@ public final class AppleCoreMLProvider: CoreMLProvider {
     /// Loaded NLContextualEmbedding instances
     private var contextualModels: [String: Any] = [:]
 
-    /// Per-id last-access timestamp for idle TTL eviction. Shared across both
-    /// `models` and `contextualModels` since the id namespaces don't overlap.
-    private var lastAccess: [String: Date] = [:]
+    /// Per-id last-access timestamps for idle TTL eviction. Kept separate per
+    /// store so that loadModel/loadContextualEmbedding using the same id (which
+    /// the existing API allows — see loadModel's guard only checks `models`)
+    /// don't conflate two different resources during eviction.
+    private var modelLastAccess: [String: Date] = [:]
+    private var contextualLastAccess: [String: Date] = [:]
+
+    /// Synchronizes access to `models`, `contextualModels`, and the two
+    /// `*LastAccess` dictionaries. The eviction timer runs on a utility queue;
+    /// public load/embed/unload methods run on the stdin thread. Without a
+    /// lock these would race — Swift's Dictionary is documented as unsafe
+    /// for concurrent mutation. NSLock is plenty: contention is low and the
+    /// critical sections are short bookkeeping ops (heavy work like CoreML
+    /// model loading happens OUTSIDE the lock).
+    private let stateLock = NSLock()
 
     /// Compiled model cache directory
     private let cacheDir: URL
@@ -141,31 +153,51 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         self.evictionTimer = timer
     }
 
-    /// Mark an id as freshly accessed so it doesn't get evicted on the next sweep.
-    private func touch(_ id: String) {
-        lastAccess[id] = Date()
+    /// Run a closure with the state lock held. Use for every dict access.
+    private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try body()
     }
 
-    /// Drop any models whose `lastAccess` is older than `modelIdleTTL`.
-    /// Safe to invoke concurrently with reads — Swift dictionary mutation on a
-    /// background queue and reads from the stdin thread already exhibit the
-    /// same data-race pattern that load/unload pairs have in the existing code;
-    /// adding eviction does not change the threading model.
+    /// Mark a custom CoreML model id as freshly accessed.
+    private func touchModel(_ id: String) {
+        withStateLock { modelLastAccess[id] = Date() }
+    }
+
+    /// Mark a contextual-embedding id as freshly accessed.
+    private func touchContextual(_ id: String) {
+        withStateLock { contextualLastAccess[id] = Date() }
+    }
+
+    /// Drop entries whose `lastAccess` is older than `modelIdleTTL` from both
+    /// stores. Held under `stateLock` so it can't race with concurrent
+    /// loadModel / embed / unload calls.
     private func evictStaleModels() {
         let cutoff = Date().addingTimeInterval(-Self.modelIdleTTL)
-        let stale = lastAccess.filter { $0.value < cutoff }.map { $0.key }
-        for id in stale {
-            models.removeValue(forKey: id)
-            contextualModels.removeValue(forKey: id)
-            lastAccess.removeValue(forKey: id)
+        withStateLock {
+            let staleModels = modelLastAccess.filter { $0.value < cutoff }.map { $0.key }
+            for id in staleModels {
+                models.removeValue(forKey: id)
+                modelLastAccess.removeValue(forKey: id)
+            }
+            let staleContextual = contextualLastAccess.filter { $0.value < cutoff }.map { $0.key }
+            for id in staleContextual {
+                contextualModels.removeValue(forKey: id)
+                contextualLastAccess.removeValue(forKey: id)
+            }
         }
     }
 
     // MARK: - Custom CoreML Models
 
     public func loadModel(id: String, options: CoreMLLoadOptions) throws -> CoreMLModelInfo {
-        guard models[id] == nil else {
-            throw JsonRpcError.invalidParams("Model already loaded with id: \(id)")
+        // Check duplicates under the lock — but a quick check first so we
+        // don't do filesystem work on an obvious dup.
+        try withStateLock {
+            if models[id] != nil {
+                throw JsonRpcError.invalidParams("Model already loaded with id: \(id)")
+            }
         }
 
         let modelURL = URL(fileURLWithPath: options.path)
@@ -207,50 +239,90 @@ public final class AppleCoreMLProvider: CoreMLProvider {
             sizeBytes: sizeBytes, modelType: "coreml"
         )
 
-        models[id] = LoadedModel(model: mlModel, info: info, modelBundle: modelBundle)
-        touch(id)
+        // Final check + insert under the lock — handles the (rare) TOCTOU
+        // window between the early check above and now.
+        try withStateLock {
+            if models[id] != nil {
+                throw JsonRpcError.invalidParams("Model already loaded with id: \(id)")
+            }
+            models[id] = LoadedModel(model: mlModel, info: info, modelBundle: modelBundle)
+            modelLastAccess[id] = Date()
+        }
         return info
     }
 
     public func unloadModel(id: String) throws {
-        if models.removeValue(forKey: id) != nil {
-            lastAccess.removeValue(forKey: id)
-            return
+        try withStateLock {
+            if models.removeValue(forKey: id) != nil {
+                modelLastAccess.removeValue(forKey: id)
+                return
+            }
+            if contextualModels.removeValue(forKey: id) != nil {
+                contextualLastAccess.removeValue(forKey: id)
+                return
+            }
+            throw JsonRpcError.invalidParams("No model loaded with id: \(id)")
         }
-        if contextualModels.removeValue(forKey: id) != nil {
-            lastAccess.removeValue(forKey: id)
-            return
-        }
-        throw JsonRpcError.invalidParams("No model loaded with id: \(id)")
     }
 
     public func modelInfo(id: String) throws -> CoreMLModelInfo {
-        if let loaded = models[id] {
-            touch(id)
-            return loaded.info
+        // Snapshot under the lock, then build the response outside.
+        enum Snapshot {
+            case model(CoreMLModelInfo)
+            case contextual(Any)
+            case missing
         }
-
-        if let model = contextualModels[id] {
-            touch(id)
+        let snap: Snapshot = withStateLock {
+            if let loaded = models[id] {
+                modelLastAccess[id] = Date()
+                return .model(loaded.info)
+            }
+            if let model = contextualModels[id] {
+                contextualLastAccess[id] = Date()
+                return .contextual(model)
+            }
+            return .missing
+        }
+        switch snap {
+        case .model(let info):
+            return info
+        case .contextual(let model):
             return contextualModelInfo(id: id, model: model)
+        case .missing:
+            throw JsonRpcError.invalidParams("No model loaded with id: \(id)")
         }
-
-        throw JsonRpcError.invalidParams("No model loaded with id: \(id)")
     }
 
     public func listModels() -> [CoreMLModelInfo] {
-        let coremlInfos = models.values.map(\.info)
-        let contextualInfos: [CoreMLModelInfo] = contextualModels.map { (id, model) in
+        // Snapshot the dictionary entries under the lock; build the info list
+        // outside so we don't hold the lock during contextualModelInfo() work.
+        struct Snapshot {
+            let coreml: [LoadedModel]
+            let contextual: [(String, Any)]
+        }
+        let snap: Snapshot = withStateLock {
+            Snapshot(coreml: Array(models.values), contextual: Array(contextualModels))
+        }
+        let coremlInfos = snap.coreml.map(\.info)
+        let contextualInfos: [CoreMLModelInfo] = snap.contextual.map { (id, model) in
             contextualModelInfo(id: id, model: model)
         }
         return coremlInfos + contextualInfos
     }
 
     public func embed(modelId: String, text: String) throws -> [Float] {
-        guard let loaded = models[modelId] else {
+        // Snapshot the LoadedModel reference under the lock, then do the
+        // (potentially heavy) embedding work outside.
+        let loaded: LoadedModel? = withStateLock {
+            if let m = models[modelId] {
+                modelLastAccess[modelId] = Date()
+                return m
+            }
+            return nil
+        }
+        guard let loaded = loaded else {
             throw JsonRpcError.invalidParams("No model loaded with id: \(modelId)")
         }
-        touch(modelId)
 
         // If swift-embeddings bundle is available (macOS 15+), use it
         if let bundle = loaded.modelBundle {
@@ -300,8 +372,10 @@ public final class AppleCoreMLProvider: CoreMLProvider {
         }
 
         try embedding.load()
-        contextualModels[id] = embedding
-        touch(id)
+        withStateLock {
+            contextualModels[id] = embedding
+            contextualLastAccess[id] = Date()
+        }
 
         return CoreMLModelInfo(
             id: id, path: "system://\(language)",
@@ -311,10 +385,15 @@ public final class AppleCoreMLProvider: CoreMLProvider {
     }
 
     public func contextualEmbed(modelId: String, text: String) throws -> [Float] {
-        guard let embedding = contextualModels[modelId] as? NLContextualEmbedding else {
+        // Snapshot under the lock, then run the embedding outside.
+        let embedding: NLContextualEmbedding? = withStateLock {
+            guard let e = contextualModels[modelId] as? NLContextualEmbedding else { return nil }
+            contextualLastAccess[modelId] = Date()
+            return e
+        }
+        guard let embedding = embedding else {
             throw JsonRpcError.invalidParams("No contextual model loaded with id: \(modelId)")
         }
-        touch(modelId)
 
         let result = try embedding.embeddingResult(for: text, language: embedding.languages.first ?? .english)
 

--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/LLMProvider.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/LLMProvider.swift
@@ -209,9 +209,40 @@ import FoundationModels
 
 @available(macOS 26, *)
 public final class AppleLLMProvider: LLMProvider {
-    private var sessions: [String: LanguageModelSession] = [:]
+    /// Idle TTL for LLM sessions. Sessions carry conversation history in memory;
+    /// a forgotten sessionClose() would otherwise leak indefinitely.
+    private static let sessionIdleTTL: TimeInterval = 1800 // 30 min
+    private static let evictionInterval: TimeInterval = 60
 
-    public init() {}
+    private var sessions: [String: LanguageModelSession] = [:]
+    private var lastAccess: [String: Date] = [:]
+    private var evictionTimer: DispatchSourceTimer?
+
+    public init() {
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.schedule(
+            deadline: .now() + Self.evictionInterval,
+            repeating: Self.evictionInterval
+        )
+        timer.setEventHandler { [weak self] in
+            self?.evictStaleSessions()
+        }
+        timer.resume()
+        self.evictionTimer = timer
+    }
+
+    private func touch(_ id: String) {
+        lastAccess[id] = Date()
+    }
+
+    private func evictStaleSessions() {
+        let cutoff = Date().addingTimeInterval(-Self.sessionIdleTTL)
+        let stale = lastAccess.filter { $0.value < cutoff }.map { $0.key }
+        for id in stale {
+            sessions.removeValue(forKey: id)
+            lastAccess.removeValue(forKey: id)
+        }
+    }
 
     public func generate(params: LLMGenerateParams) throws -> LLMGenerateResult {
         let session = makeSession(instructions: params.systemInstructions)
@@ -343,12 +374,14 @@ public final class AppleLLMProvider: LLMProvider {
 
         let session = makeSession(instructions: params.instructions)
         sessions[params.sessionId] = session
+        touch(params.sessionId)
     }
 
     public func sessionRespond(params: LLMSessionRespondParams) throws -> LLMGenerateResult {
         guard let session = sessions[params.sessionId] else {
             throw JsonRpcError.invalidParams("No session with id: \(params.sessionId)")
         }
+        touch(params.sessionId)
 
         let options = makeOptions(temperature: params.temperature, maxTokens: params.maxTokens)
 
@@ -379,6 +412,7 @@ public final class AppleLLMProvider: LLMProvider {
         guard sessions.removeValue(forKey: sessionId) != nil else {
             throw JsonRpcError.invalidParams("No session with id: \(sessionId)")
         }
+        lastAccess.removeValue(forKey: sessionId)
     }
 
     public func available() -> LLMAvailabilityResult {

--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/LLMProvider.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Providers/LLMProvider.swift
@@ -218,6 +218,12 @@ public final class AppleLLMProvider: LLMProvider {
     private var lastAccess: [String: Date] = [:]
     private var evictionTimer: DispatchSourceTimer?
 
+    /// Synchronizes access to `sessions` and `lastAccess`. The eviction timer
+    /// fires on a utility queue; sessionCreate / sessionRespond / sessionClose
+    /// run on the stdin thread. NSLock keeps them serialized — Swift Dictionary
+    /// mutation under concurrent access is undefined behavior.
+    private let stateLock = NSLock()
+
     public init() {
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
         timer.schedule(
@@ -231,16 +237,20 @@ public final class AppleLLMProvider: LLMProvider {
         self.evictionTimer = timer
     }
 
-    private func touch(_ id: String) {
-        lastAccess[id] = Date()
+    private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try body()
     }
 
     private func evictStaleSessions() {
         let cutoff = Date().addingTimeInterval(-Self.sessionIdleTTL)
-        let stale = lastAccess.filter { $0.value < cutoff }.map { $0.key }
-        for id in stale {
-            sessions.removeValue(forKey: id)
-            lastAccess.removeValue(forKey: id)
+        withStateLock {
+            let stale = lastAccess.filter { $0.value < cutoff }.map { $0.key }
+            for id in stale {
+                sessions.removeValue(forKey: id)
+                lastAccess.removeValue(forKey: id)
+            }
         }
     }
 
@@ -368,20 +378,29 @@ public final class AppleLLMProvider: LLMProvider {
     }
 
     public func sessionCreate(params: LLMSessionCreateParams) throws {
-        guard sessions[params.sessionId] == nil else {
-            throw JsonRpcError.invalidParams("Session already exists: \(params.sessionId)")
-        }
-
         let session = makeSession(instructions: params.instructions)
-        sessions[params.sessionId] = session
-        touch(params.sessionId)
+        try withStateLock {
+            if sessions[params.sessionId] != nil {
+                throw JsonRpcError.invalidParams("Session already exists: \(params.sessionId)")
+            }
+            sessions[params.sessionId] = session
+            lastAccess[params.sessionId] = Date()
+        }
     }
 
     public func sessionRespond(params: LLMSessionRespondParams) throws -> LLMGenerateResult {
-        guard let session = sessions[params.sessionId] else {
+        // Snapshot the session reference under the lock, then perform the
+        // potentially long-running `session.respond(...)` outside.
+        let session: LanguageModelSession? = withStateLock {
+            if let s = sessions[params.sessionId] {
+                lastAccess[params.sessionId] = Date()
+                return s
+            }
+            return nil
+        }
+        guard let session = session else {
             throw JsonRpcError.invalidParams("No session with id: \(params.sessionId)")
         }
-        touch(params.sessionId)
 
         let options = makeOptions(temperature: params.temperature, maxTokens: params.maxTokens)
 
@@ -409,10 +428,12 @@ public final class AppleLLMProvider: LLMProvider {
     }
 
     public func sessionClose(sessionId: String) throws {
-        guard sessions.removeValue(forKey: sessionId) != nil else {
-            throw JsonRpcError.invalidParams("No session with id: \(sessionId)")
+        try withStateLock {
+            guard sessions.removeValue(forKey: sessionId) != nil else {
+                throw JsonRpcError.invalidParams("No session with id: \(sessionId)")
+            }
+            lastAccess.removeValue(forKey: sessionId)
         }
-        lastAccess.removeValue(forKey: sessionId)
     }
 
     public func available() -> LLMAvailabilityResult {

--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Server/JsonRpcServer.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Server/JsonRpcServer.swift
@@ -34,14 +34,14 @@ public final class JsonRpcServer: NotificationSink {
         // Ignore SIGPIPE so broken-pipe returns EPIPE instead of killing the process
         signal(SIGPIPE, SIG_IGN)
 
-        // Clean shutdown on SIGTERM / SIGINT from the parent. The handler must be
-        // async-signal-safe — no Swift framework calls, just a stderr write and
-        // Darwin.exit(0). The SDK's close() escalates to these signals when
-        // stdin.end() doesn't produce graceful exit fast enough.
+        // Clean shutdown on SIGTERM / SIGINT from the parent. The handler MUST
+        // be strictly async-signal-safe — no allocations, no Swift `String`
+        // APIs (withCString / etc. are not in the POSIX safe list), and
+        // `_exit(2)` instead of `exit(3)` (the latter runs atexit handlers and
+        // is not async-signal-safe). The SDK's close() escalates to these
+        // signals when stdin.end() doesn't produce graceful exit fast enough.
         let shutdownHandler: @convention(c) (Int32) -> Void = { _ in
-            let msg = "[darwinkit] received signal, exiting\n"
-            msg.withCString { _ = Darwin.write(STDERR_FILENO, $0, strlen($0)) }
-            Darwin.exit(0)
+            Darwin._exit(0)
         }
         signal(SIGTERM, shutdownHandler)
         signal(SIGINT, shutdownHandler)

--- a/packages/darwinkit-swift/Sources/DarwinKitCore/Server/JsonRpcServer.swift
+++ b/packages/darwinkit-swift/Sources/DarwinKitCore/Server/JsonRpcServer.swift
@@ -34,9 +34,51 @@ public final class JsonRpcServer: NotificationSink {
         // Ignore SIGPIPE so broken-pipe returns EPIPE instead of killing the process
         signal(SIGPIPE, SIG_IGN)
 
+        // Clean shutdown on SIGTERM / SIGINT from the parent. The handler must be
+        // async-signal-safe — no Swift framework calls, just a stderr write and
+        // Darwin.exit(0). The SDK's close() escalates to these signals when
+        // stdin.end() doesn't produce graceful exit fast enough.
+        let shutdownHandler: @convention(c) (Int32) -> Void = { _ in
+            let msg = "[darwinkit] received signal, exiting\n"
+            msg.withCString { _ = Darwin.write(STDERR_FILENO, $0, strlen($0)) }
+            Darwin.exit(0)
+        }
+        signal(SIGTERM, shutdownHandler)
+        signal(SIGINT, shutdownHandler)
+
         // Disable stdout buffering — critical when piped to a parent process.
         // Without this, responses accumulate in a 4KB buffer and the parent never sees them.
         setbuf(stdout, nil)
+
+        // Watch the parent PID via kqueue NOTE_EXIT. This is faster + more
+        // reliable than waiting for stdin EOF — when the parent is SIGKILL'd
+        // by the OS (e.g. OOM), the EOF arrives only after the kernel closes
+        // the pipe, which can race with us being mid-call. NOTE_EXIT fires
+        // immediately on parent termination.
+        let parentPid = getppid()
+        if parentPid > 1 {
+            let kq = kqueue()
+            if kq != -1 {
+                var ev = kevent(
+                    ident: UInt(parentPid),
+                    filter: Int16(EVFILT_PROC),
+                    flags: UInt16(EV_ADD | EV_ENABLE | EV_ONESHOT),
+                    fflags: UInt32(NOTE_EXIT),
+                    data: 0,
+                    udata: nil
+                )
+                if kevent(kq, &ev, 1, nil, 0, nil) != -1 {
+                    DispatchQueue.global(qos: .utility).async {
+                        var out = kevent()
+                        if kevent(kq, nil, 0, &out, 1, nil) > 0 {
+                            let msg = "[darwinkit] parent (\(parentPid)) exited, shutting down\n"
+                            msg.withCString { _ = Darwin.write(STDERR_FILENO, $0, strlen($0)) }
+                            Darwin.exit(0)
+                        }
+                    }
+                }
+            }
+        }
 
         // Send ready notification so parent knows we're alive and what we support
         let capabilities = router.availableMethods()
@@ -53,7 +95,7 @@ public final class JsonRpcServer: NotificationSink {
             }
             // stdin closed — parent process is done
             self.log("stdin closed, shutting down")
-            exit(0)
+            Darwin.exit(0)
         }
         stdinThread.name = "darwinkit.stdin"
         stdinThread.start()

--- a/packages/darwinkit/README.md
+++ b/packages/darwinkit/README.md
@@ -31,8 +31,33 @@ console.log(vector.length) // 512
 const { text } = await dk.vision.ocr({ path: "/tmp/screenshot.png" })
 console.log(text)
 
-dk.close()
+await dk.close() // gracefully shut down the Swift child
 ```
+
+### Explicit-resource-management (recommended)
+
+With TypeScript 5.2+ / Node 20.4+ you can use the `using` syntax to get
+deterministic shutdown without a manual `close()`:
+
+```typescript
+import { DarwinKit } from "@genesiscz/darwinkit"
+
+{
+  await using dk = new DarwinKit()
+  const lang = await dk.nlp.language({ text: "Bonjour" })
+  console.log(lang)
+} // ← Swift child shut down here, no leaks even on throw
+```
+
+### Lifecycle notes
+
+- `dk.close()` is **idempotent** and escalates `stdin.end()` → `SIGTERM` → `SIGKILL`
+  if the child doesn't honour graceful shutdown within 500 ms per step.
+- The SDK calls `child.unref()` on the spawned process and stdio pipes, so a
+  short-lived consumer that **forgets** to call `close()` can still exit
+  naturally — and a global `process.on('exit')` reaper SIGKILLs any survivors.
+  You should still call `close()` for prompt cleanup; the safety nets exist so
+  one missed call doesn't accumulate zombies across hundreds of CLI invocations.
 
 ## Features
 

--- a/packages/darwinkit/src/__tests__/lifecycle.test.ts
+++ b/packages/darwinkit/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { DarwinKit } from "../client.js";
+
+async function countLiveChildren(parentPid: number): Promise<number> {
+  const ps = Bun.spawnSync(["pgrep", "-P", String(parentPid), "-f", "darwinkit"]);
+  if (ps.exitCode !== 0) return 0;
+  return ps.stdout
+    .toString()
+    .trim()
+    .split("\n")
+    .filter(Boolean).length;
+}
+
+async function waitUntil(
+  predicate: () => Promise<boolean> | boolean,
+  budgetMs: number,
+  stepMs = 50,
+): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < budgetMs) {
+    if (await predicate()) return true;
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+  return predicate() as Promise<boolean>;
+}
+
+describe("DarwinKit lifecycle", () => {
+  test(
+    "close() terminates the child within 2s",
+    async () => {
+      const dk = new DarwinKit({ logLevel: "silent" });
+      await dk.connect();
+      expect(await countLiveChildren(process.pid)).toBe(1);
+
+      // Note: pre-fix close() is sync; post-fix it becomes async. await works for both.
+      await (dk.close() as unknown as Promise<void> | void);
+
+      const ok = await waitUntil(async () => (await countLiveChildren(process.pid)) === 0, 2_000);
+      expect(ok).toBe(true);
+    },
+    10_000,
+  );
+
+  test(
+    "Node process exits within 5s after a request completes (no child holds the event loop)",
+    async () => {
+      const sdkDist = `${import.meta.dir}/../../dist/index.js`;
+      const script = `
+        import { DarwinKit } from "${sdkDist}";
+        const dk = new DarwinKit({ logLevel: "silent" });
+        await dk.system.capabilities();
+        // intentionally NO dk.close() — exercises the unref path
+      `;
+      const start = Date.now();
+      const proc = Bun.spawn(["bun", "-e", script], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // Race the natural exit against a hard budget so a hung child doesn't hang the test.
+      const exitedNaturally = await Promise.race([
+        proc.exited.then(() => true),
+        new Promise<false>((r) => setTimeout(() => r(false), 5_000)),
+      ]);
+
+      const elapsed = Date.now() - start;
+      if (!exitedNaturally) {
+        proc.kill("SIGKILL");
+        await proc.exited;
+      }
+      expect(exitedNaturally).toBe(true);
+      expect(proc.exitCode).toBe(0);
+      expect(elapsed).toBeLessThan(5_000);
+    },
+    15_000,
+  );
+
+  test(
+    "Parent SIGKILL leaves no orphan grand-child after 2s",
+    async () => {
+      const sdkDist = `${import.meta.dir}/../../dist/index.js`;
+      const inner = `
+        import { DarwinKit } from "${sdkDist}";
+        const dk = new DarwinKit({ logLevel: "silent" });
+        await dk.connect();
+        await new Promise(() => {}); // hang
+      `;
+      const proc = Bun.spawn(["bun", "-e", inner], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // Wait until darwinkit child is up
+      const childUp = await waitUntil(
+        async () => (await countLiveChildren(proc.pid)) >= 1,
+        5_000,
+      );
+      expect(childUp).toBe(true);
+
+      proc.kill("SIGKILL");
+
+      const ok = await waitUntil(
+        async () => (await countLiveChildren(proc.pid)) === 0,
+        3_000,
+      );
+      expect(ok).toBe(true);
+    },
+    15_000,
+  );
+});

--- a/packages/darwinkit/src/__tests__/lifecycle.test.ts
+++ b/packages/darwinkit/src/__tests__/lifecycle.test.ts
@@ -11,6 +11,26 @@ async function countLiveChildren(parentPid: number): Promise<number> {
     .filter(Boolean).length;
 }
 
+/** Return the current direct-child darwinkit PIDs of `parentPid`. */
+function listChildPids(parentPid: number): number[] {
+  const ps = Bun.spawnSync(["pgrep", "-P", String(parentPid), "-f", "darwinkit"]);
+  if (ps.exitCode !== 0) return [];
+  return ps.stdout
+    .toString()
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n));
+}
+
+/** True iff a process with `pid` currently exists (any state). */
+function pidExists(pid: number): boolean {
+  // `kill -0` returns 0 if the process exists, 1 (ESRCH) if not.
+  const ps = Bun.spawnSync(["kill", "-0", String(pid)]);
+  return ps.exitCode === 0;
+}
+
 async function waitUntil(
   predicate: () => Promise<boolean> | boolean,
   budgetMs: number,
@@ -96,10 +116,18 @@ describe("DarwinKit lifecycle", () => {
       );
       expect(childUp).toBe(true);
 
+      // Capture the concrete child PIDs BEFORE killing the parent. After SIGKILL,
+      // any orphan darwinkit gets reparented to launchd (PID 1), so a
+      // `pgrep -P <dead-parent>` check would falsely return 0 even if the
+      // orphan still exists. Tracking explicit PIDs + `kill -0` is reliable.
+      const trackedChildren = listChildPids(proc.pid);
+      expect(trackedChildren.length).toBeGreaterThan(0);
+
       proc.kill("SIGKILL");
+      await proc.exited;
 
       const ok = await waitUntil(
-        async () => (await countLiveChildren(proc.pid)) === 0,
+        () => trackedChildren.every((pid) => !pidExists(pid)),
         3_000,
       );
       expect(ok).toBe(true);

--- a/packages/darwinkit/src/__tests__/lifecycle.test.ts
+++ b/packages/darwinkit/src/__tests__/lifecycle.test.ts
@@ -32,8 +32,7 @@ describe("DarwinKit lifecycle", () => {
       await dk.connect();
       expect(await countLiveChildren(process.pid)).toBe(1);
 
-      // Note: pre-fix close() is sync; post-fix it becomes async. await works for both.
-      await (dk.close() as unknown as Promise<void> | void);
+      await dk.close();
 
       const ok = await waitUntil(async () => (await countLiveChildren(process.pid)) === 0, 2_000);
       expect(ok).toBe(true);

--- a/packages/darwinkit/src/client.ts
+++ b/packages/darwinkit/src/client.ts
@@ -25,6 +25,35 @@ import { Reminders } from "./namespaces/reminders.js";
 import { Notifications } from "./namespaces/notifications.js";
 
 // ---------------------------------------------------------------------------
+// Process-exit reaper (defense in depth)
+// ---------------------------------------------------------------------------
+// Every live DarwinKit registers itself here so that on Node exit — for any
+// reason (natural completion, process.exit, uncaught exception, SIGINT/SIGTERM
+// that the user didn't handle and Node's default handler turns into exit) —
+// we SIGKILL the child synchronously. Runs in the 'exit' phase so we can't
+// await; just fire-and-forget kill() and let the kernel reap.
+
+const liveInstances = new Set<DarwinKit>();
+let reaperInstalled = false;
+
+function installReaper(): void {
+  if (reaperInstalled) return;
+  reaperInstalled = true;
+  process.on("exit", () => {
+    for (const dk of liveInstances) {
+      // Access transport via the internal property — synchronous SIGKILL only,
+      // no awaits allowed in 'exit' handlers.
+      const t = (dk as unknown as { transport: { kill: (s: NodeJS.Signals) => void } }).transport;
+      try {
+        t.kill("SIGKILL");
+      } catch {
+        // ignore — already dead
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
@@ -153,6 +182,9 @@ export class DarwinKit implements DarwinKitClient {
     this.calendar = new Calendar(this);
     this.reminders = new Reminders(this);
     this.notifications = new Notifications(this);
+
+    installReaper();
+    liveInstances.add(this);
   }
 
   get connected(): boolean {
@@ -182,6 +214,10 @@ export class DarwinKit implements DarwinKitClient {
    * guarantees the child has actually terminated before returning.
    */
   async close(): Promise<void> {
+    // Deregister from the reaper as soon as close() is invoked — even if we
+    // throw or the SIGKILL escalation never fires, we don't want to double-kill.
+    liveInstances.delete(this);
+
     // Idempotent: if we already closed cleanly, nothing to do.
     if (this.intentionallyClosed && this.transport.hasExited()) return;
     this.intentionallyClosed = true;

--- a/packages/darwinkit/src/client.ts
+++ b/packages/darwinkit/src/client.ts
@@ -41,11 +41,10 @@ function installReaper(): void {
   reaperInstalled = true;
   process.on("exit", () => {
     for (const dk of liveInstances) {
-      // Access transport via the internal property — synchronous SIGKILL only,
-      // no awaits allowed in 'exit' handlers.
-      const t = (dk as unknown as { transport: { kill: (s: NodeJS.Signals) => void } }).transport;
+      // Use the dedicated internal method instead of a private-field cast —
+      // keeps the contract typed and stable if Transport's surface evolves.
       try {
-        t.kill("SIGKILL");
+        dk._killForReaper();
       } catch {
         // ignore — already dead
       }
@@ -209,6 +208,12 @@ export class DarwinKit implements DarwinKitClient {
    *   3. SIGTERM, wait another 500ms
    *   4. SIGKILL, wait another 500ms
    *
+   * The signals target the ChildProcess instance captured at the moment
+   * `transport.stop()` was called — NOT the mutable `transport.process` field.
+   * This makes `dk.close()` safe to overlap with a subsequent `dk.connect()`:
+   * the new child can spawn during the grace window without being SIGTERM'd
+   * by an in-flight close on the previous one.
+   *
    * Idempotent. Awaiting is optional — fire-and-forget `dk.close()` still
    * works (existing call sites need not change), but `await dk.close()`
    * guarantees the child has actually terminated before returning.
@@ -216,6 +221,7 @@ export class DarwinKit implements DarwinKitClient {
   async close(): Promise<void> {
     // Deregister from the reaper as soon as close() is invoked — even if we
     // throw or the SIGKILL escalation never fires, we don't want to double-kill.
+    // (If the consumer reconnects afterward, doConnect() re-adds the instance.)
     liveInstances.delete(this);
 
     // Idempotent: if we already closed cleanly, nothing to do.
@@ -224,6 +230,8 @@ export class DarwinKit implements DarwinKitClient {
     this._connected = false;
     this.connectPromise = null;
 
+    // Capture the live ChildProcess before we touch the transport's mutable
+    // state. All subsequent kill() calls target THIS proc, not transport.process.
     const proc = this.transport.stop();
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);
@@ -231,11 +239,16 @@ export class DarwinKit implements DarwinKitClient {
     }
     this.pending.clear();
 
-    if (!proc || this.transport.hasExited()) return;
+    if (!proc) return;
+
+    const procExited = (): boolean =>
+      proc.exitCode !== null || proc.signalCode !== null;
+
+    if (procExited()) return;
 
     const waitForExit = (ms: number): Promise<void> =>
       new Promise((resolve) => {
-        if (this.transport.hasExited()) return resolve();
+        if (procExited()) return resolve();
         const t = setTimeout(resolve, ms);
         proc.once("exit", () => {
           clearTimeout(t);
@@ -243,13 +256,35 @@ export class DarwinKit implements DarwinKitClient {
         });
       });
 
+    const killProc = (signal: NodeJS.Signals): void => {
+      try {
+        proc.kill(signal);
+      } catch {
+        // already dead
+      }
+    };
+
     await waitForExit(500);
-    if (this.transport.hasExited()) return;
-    this.transport.kill("SIGTERM");
+    if (procExited()) return;
+    killProc("SIGTERM");
     await waitForExit(500);
-    if (this.transport.hasExited()) return;
-    this.transport.kill("SIGKILL");
+    if (procExited()) return;
+    killProc("SIGKILL");
     await waitForExit(500);
+  }
+
+  /**
+   * @internal
+   * Synchronous kill used by the module-level exit reaper. Calls `transport.kill`
+   * directly so it can fire in Node's `process.on("exit")` phase where awaits
+   * are not allowed. Not part of the public API — do not call from user code.
+   */
+  _killForReaper(): void {
+    try {
+      this.transport.kill("SIGKILL");
+    } catch {
+      // already dead
+    }
   }
 
   /** Sync dispose for `using dk = new DarwinKit()` — fire-and-forget close. */
@@ -371,6 +406,11 @@ export class DarwinKit implements DarwinKitClient {
 
   private async doConnect(): Promise<ReadyNotification> {
     this.intentionallyClosed = false;
+
+    // Re-register with the exit reaper on every connect. close() removes the
+    // instance; without this re-add the reaper wouldn't track a reused client
+    // after `await dk.close(); await dk.connect()`. Set.add is idempotent.
+    liveInstances.add(this);
 
     if (!this.resolvedBinary) {
       this.log("debug", "Resolving binary...");

--- a/packages/darwinkit/src/client.ts
+++ b/packages/darwinkit/src/client.ts
@@ -169,18 +169,51 @@ export class DarwinKit implements DarwinKitClient {
   }
 
   /**
-   * Gracefully close the server by closing stdin.
+   * Gracefully close the server.
+   *
+   * Lifecycle:
+   *   1. Close stdin → child should see EOF and exit naturally
+   *   2. Wait up to 500ms for graceful exit
+   *   3. SIGTERM, wait another 500ms
+   *   4. SIGKILL, wait another 500ms
+   *
+   * Idempotent. Awaiting is optional — fire-and-forget `dk.close()` still
+   * works (existing call sites need not change), but `await dk.close()`
+   * guarantees the child has actually terminated before returning.
    */
-  close(): void {
+  async close(): Promise<void> {
+    // Idempotent: if we already closed cleanly, nothing to do.
+    if (this.intentionallyClosed && this.transport.hasExited()) return;
     this.intentionallyClosed = true;
     this._connected = false;
     this.connectPromise = null;
-    this.transport.stop();
+
+    const proc = this.transport.stop();
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);
       pending.reject(new Error("Client closed"));
     }
     this.pending.clear();
+
+    if (!proc || this.transport.hasExited()) return;
+
+    const waitForExit = (ms: number): Promise<void> =>
+      new Promise((resolve) => {
+        if (this.transport.hasExited()) return resolve();
+        const t = setTimeout(resolve, ms);
+        proc.once("exit", () => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+
+    await waitForExit(500);
+    if (this.transport.hasExited()) return;
+    this.transport.kill("SIGTERM");
+    await waitForExit(500);
+    if (this.transport.hasExited()) return;
+    this.transport.kill("SIGKILL");
+    await waitForExit(500);
   }
 
   // ─── JSON-RPC call ──────────────────────────────────────

--- a/packages/darwinkit/src/client.ts
+++ b/packages/darwinkit/src/client.ts
@@ -252,6 +252,16 @@ export class DarwinKit implements DarwinKitClient {
     await waitForExit(500);
   }
 
+  /** Sync dispose for `using dk = new DarwinKit()` — fire-and-forget close. */
+  [Symbol.dispose](): void {
+    void this.close();
+  }
+
+  /** Async dispose for `await using dk = new DarwinKit()` — awaits full shutdown. */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
   // ─── JSON-RPC call ──────────────────────────────────────
 
   async call<M extends MethodName>(

--- a/packages/darwinkit/src/transport.ts
+++ b/packages/darwinkit/src/transport.ts
@@ -49,6 +49,7 @@ export class Transport {
       this.rl?.close();
       this.rl = null;
       options.onExit(code);
+      this.process = null;
     });
 
     // Pipe stderr for debugging
@@ -64,13 +65,42 @@ export class Transport {
     this.process.stdin.write(json + "\n");
   }
 
-  stop(): void {
+  /**
+   * Graceful: close stdin so the child sees EOF and exits on its own.
+   * Returns the still-live ChildProcess so the caller can await its `exit`
+   * event or escalate with kill(). Does NOT null `this.process` — the
+   * `exit` handler does that, so kill() works during the escalation window.
+   */
+  stop(): ChildProcess | null {
     this._alive = false;
     this.rl?.close();
     this.rl = null;
-    if (this.process?.stdin?.writable) {
-      this.process.stdin.end();
+    const proc = this.process;
+    if (proc?.stdin?.writable) {
+      try {
+        proc.stdin.end();
+      } catch {
+        // ignore broken pipe
+      }
     }
-    this.process = null;
+    return proc;
+  }
+
+  /** Forceful: send signal, swallow errors if the child is already dead. */
+  kill(signal: NodeJS.Signals = "SIGTERM"): void {
+    try {
+      this.process?.kill(signal);
+    } catch {
+      // already dead
+    }
+  }
+
+  /** Has the underlying child exited (or never started)? */
+  hasExited(): boolean {
+    return (
+      !this.process ||
+      this.process.exitCode !== null ||
+      this.process.signalCode !== null
+    );
   }
 }

--- a/packages/darwinkit/src/transport.ts
+++ b/packages/darwinkit/src/transport.ts
@@ -26,6 +26,14 @@ export class Transport {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
+    // Let Node's event loop exit even if user code never calls close().
+    // We unref the child handle AND the stdio pipes — otherwise the readline
+    // 'data' listener on stdout keeps the loop alive forever.
+    // Don't unref stdin: we need it writable.
+    this.process.unref();
+    this.process.stdout?.unref?.();
+    this.process.stderr?.unref?.();
+
     this._alive = true;
 
     this.rl = createInterface({ input: this.process.stdout! });


### PR DESCRIPTION
## Summary

Fixes a process-lifecycle bug that accumulated `darwinkit serve` Swift child processes on dev machines (64 alive after ~3 days on one machine, ultimately triggering the macOS "Your system has run out of application memory" dialog). Adds defense-in-depth so the bug can't recur.

**Root cause:** the SDK called `child_process.spawn()` without `unref()` and the `readline` listener kept the stdio pipes ref'd, so Node's event loop refused to exit even when user code was done. Consumers that forgot to call `dk.close()` (e.g. short-lived CLIs at the end of a Claude Code turn) leaked one zombie pair per invocation.

## Changes

**TypeScript SDK (`packages/darwinkit/`):**
- `unref()` the spawned child and its stdout/stderr pipes so Node can exit naturally when idle (`ed5e509`)
- `close()` is now async and escalates `stdin.end()` → 500ms wait → `SIGTERM` → 500ms → `SIGKILL` (`c07c68b`)
- Module-level `process.on('exit')` reaper SIGKILLs any still-live child when Node exits for any reason — natural completion, `process.exit`, uncaught exception, unhandled SIGINT/SIGTERM (`09a97a8`)
- `[Symbol.dispose]` / `[Symbol.asyncDispose]` for `using dk = new DarwinKit()` (`793ed01`)
- Lifecycle test suite covering close timing, idle Node-exit, and parent-SIGKILL orphan check (`9534f71`)

**Swift server (`packages/darwinkit-swift/`):**
- `signal(SIGTERM/SIGINT)` async-signal-safe handlers so the SDK's escalation actually terminates the child at each stage (`f856c67`)
- `kqueue NOTE_EXIT` watcher on `getppid()` for active parent-death detection — faster + more reliable than waiting for stdin EOF, which can race when the parent is SIGKILL'd by the OS (e.g. OOM)
- `DispatchSourceTimer` TTL eviction for `CoreMLProvider.models` / `contextualModels` (10 min idle) and `LLMProvider.sessions` (30 min idle) — bounds per-process memory growth from forgotten unloads (`f5f30f2`)

## Verification

| Scenario | SDK | Result |
|---|---|---|
| Broken 0.7.4 + consumer that forgets close() | broken | hangs ≥ 8 s, leaks parent + child |
| **Fixed SDK** + same broken consumer | fixed | exits ≤ 1 s, zero leak |

End-to-end replication done with the broken SDK restored in `node_modules` then re-swapped to fixed — same `bun notify "test"` invocation that hung 8+ s now completes in well under 1 s.

All 243 pre-existing Swift tests pass; 3 new SDK lifecycle tests pass.

## Test plan

- [x] `cd packages/darwinkit && bun run build && bun test src/__tests__/lifecycle.test.ts` — all 3 pass
- [x] `cd packages/darwinkit-swift && swift test` — 243/243 pass
- [x] End-to-end repro on broken SDK confirms hang
- [x] End-to-end repro on fixed SDK confirms exit ≤ 1 s
- [ ] CI green
- [ ] After merge: `./release.sh 0.7.5` → npm publish via OIDC

## Notes for reviewer

- `dk.close()` returns `Promise<void>` now (was `void`). Existing fire-and-forget callers continue to work — the awaitable semantics are additive.
- The reaper accesses `transport` via a typed cast since `transport` is `private`; alternatively we could expose a tiny `_killSync()` method, but the cast is local to one closure and keeps the public API unchanged.
- `Symbol.dispose` requires `lib: ["esnext.disposable"]` or TypeScript 5.2+. The SDK's `tsconfig.json` already targets latest. Consumers on older TS will see `using` syntax as an error but the methods themselves work fine when called directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async close() with deterministic resource disposal (supports using/async-using).
  * Automatic eviction of idle models and LLM sessions.
  * Process reaper and improved child-process handling (better unref/kill/exit reporting).
  * Parent-process monitoring and explicit shutdown signal handling.

* **Bug Fixes**
  * Improved process cleanup to prevent orphaned child processes.

* **Documentation**
  * Added lifecycle management guidelines and shutdown escalation steps.

* **Tests**
  * Added lifecycle tests for process termination and orphan prevention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/darwinkit-swift/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->